### PR TITLE
:green_heart: Harden Bookshelf workflows

### DIFF
--- a/.github/workflows/bookshelf-close-issue.yml
+++ b/.github/workflows/bookshelf-close-issue.yml
@@ -2,27 +2,30 @@ name: "Bookshelf Action: Close Issue"
 on:
   issues:
     types: [closed]
+permissions:
+  contents: write
+  issues: write
 jobs:
   bookshelf-action:
     name: Bookshelf Action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Run Bookshelf Action
         uses: AnandChowdhary/bookshelf-action@HEAD
         with:
           command: "onCloseIssue"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Delay for 10 seconds
         if: github.repository == 'AnandChowdhary/books'
         run: sleep 10
       - name: Dispatch AnandChowdhary/everything update
         if: github.repository == 'AnandChowdhary/books'
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           repo: AnandChowdhary/everything

--- a/.github/workflows/bookshelf-config.yml
+++ b/.github/workflows/bookshelf-config.yml
@@ -4,19 +4,21 @@ on:
     paths:
       - ".bookshelfrc.yml"
   workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
 jobs:
   bookshelf-action:
     name: Bookshelf Action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Run Bookshelf Action
         uses: AnandChowdhary/bookshelf-action@HEAD
         with:
           command: "updateSummary"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/bookshelf-issue-comment.yml
+++ b/.github/workflows/bookshelf-issue-comment.yml
@@ -2,19 +2,21 @@ name: "Bookshelf Action: Issue Comment"
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: write
+  issues: write
 jobs:
   bookshelf-action:
     name: Bookshelf Action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Run Bookshelf Action
         uses: AnandChowdhary/bookshelf-action@HEAD
         with:
           command: "onIssueComment"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/bookshelf-new-issue.yml
+++ b/.github/workflows/bookshelf-new-issue.yml
@@ -2,27 +2,30 @@ name: "Bookshelf Action: New Issue"
 on:
   issues:
     types: [opened]
+permissions:
+  contents: write
+  issues: write
 jobs:
   bookshelf-action:
     name: Bookshelf Action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Run Bookshelf Action
         uses: AnandChowdhary/bookshelf-action@HEAD
         with:
           command: "onNewIssue"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Delay for 10 seconds
         if: github.repository == 'AnandChowdhary/books'
         run: sleep 10
       - name: Dispatch AnandChowdhary/everything update
         if: github.repository == 'AnandChowdhary/books'
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           repo: AnandChowdhary/everything


### PR DESCRIPTION
## Summary
- modernizes the Bookshelf workflows to `actions/checkout@v4`
- uses the built-in `github.token` explicitly for checkout and Bookshelf Action commands
- declares the write permissions the Bookshelf workflows need to update issues and repository content
- makes the optional `AnandChowdhary/everything` dispatch non-blocking so a downstream dispatch problem does not mark the primary Bookshelf update failed

## Test plan
- Parsed all workflow YAML with PyYAML
- Ran `actionlint` against all workflow files
- Ran `git diff --cached --check`
- Ran added-line security scan: no findings

Refs failed Bookshelf Action: Close Issue run 15488262172.